### PR TITLE
use to_be_bytes / from_be_bytes to remove unsafe code.

### DIFF
--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -1,18 +1,5 @@
 use bare_io as io;
-use core::ptr::copy_nonoverlapping;
 use io::Result;
-
-macro_rules! read_num_bytes {
-    ($ty:ty, $size:expr, $src:expr, $which:ident) => {{
-        assert!($size == ::core::mem::size_of::<$ty>());
-        assert!($size <= $src.len());
-        let mut data: $ty = 0;
-        unsafe {
-            copy_nonoverlapping($src.as_ptr(), &mut data as *mut $ty as *mut u8, $size);
-        }
-        data.$which()
-    }};
-}
 
 pub trait ReadBytesExt: io::Read {
     #[inline]
@@ -33,28 +20,28 @@ pub trait ReadBytesExt: io::Read {
     fn read_u16(&mut self) -> Result<u16> {
         let mut buf = [0; 2];
         self.read_exact(&mut buf)?;
-        Ok(read_num_bytes!(u16, 2, buf, to_be))
+        Ok(u16::from_be_bytes(buf))
     }
 
     #[inline]
     fn read_i16(&mut self) -> Result<i16> {
         let mut buf = [0; 2];
         self.read_exact(&mut buf)?;
-        Ok(read_num_bytes!(i16, 2, buf, to_be))
+        Ok(i16::from_be_bytes(buf))
     }
 
     #[inline]
     fn read_u32(&mut self) -> Result<u32> {
         let mut buf = [0; 4];
         self.read_exact(&mut buf)?;
-        Ok(read_num_bytes!(u32, 4, buf, to_be))
+        Ok(u32::from_be_bytes(buf))
     }
 
     #[inline]
     fn read_i32(&mut self) -> Result<i32> {
         let mut buf = [0; 4];
         self.read_exact(&mut buf)?;
-        Ok(read_num_bytes!(i32, 4, buf, to_be))
+        Ok(i32::from_be_bytes(buf))
     }
 }
 

--- a/src/ser/write.rs
+++ b/src/ser/write.rs
@@ -1,17 +1,5 @@
 use bare_io as io;
 use bare_io::Result;
-use core::mem::transmute;
-use core::ptr::copy_nonoverlapping;
-
-macro_rules! write_num_bytes {
-    ($ty:ty, $size:expr, $n:expr, $dst:expr, $which:ident) => {{
-        assert!($size <= $dst.len());
-        unsafe {
-            let bytes = transmute::<_, [u8; $size]>($n.$which());
-            copy_nonoverlapping((&bytes).as_ptr(), $dst.as_mut_ptr(), $size);
-        }
-    }};
-}
 
 pub trait WriteBytesExt: io::Write {
     #[inline]
@@ -26,29 +14,25 @@ pub trait WriteBytesExt: io::Write {
 
     #[inline]
     fn write_u16(&mut self, n: u16) -> Result<()> {
-        let mut buf = [0; 2];
-        write_num_bytes!(u16, 2, n, buf, to_be);
+        let buf = u16::to_be_bytes(n);
         self.write_all(&buf)
     }
 
     #[inline]
     fn write_i16(&mut self, n: i16) -> Result<()> {
-        let mut buf = [0; 2];
-        write_num_bytes!(i16, 2, n, buf, to_be);
+        let buf = i16::to_be_bytes(n);
         self.write_all(&buf)
     }
 
     #[inline]
     fn write_u32(&mut self, n: u32) -> Result<()> {
-        let mut buf = [0; 4];
-        write_num_bytes!(u32, 4, n, buf, to_be);
+        let buf = u32::to_be_bytes(n);
         self.write_all(&buf)
     }
 
     #[inline]
     fn write_i32(&mut self, n: i32) -> Result<()> {
-        let mut buf = [0; 4];
-        write_num_bytes!(i32, 4, n, buf, to_be);
+        let buf = i32::to_be_bytes(n);
         self.write_all(&buf)
     }
 }


### PR DESCRIPTION
fix #20 