### PR TITLE
neat: applying cargo clippy --fix

### DIFF
--- a/echonet-lite-core/examples/find.rs
+++ b/echonet-lite-core/examples/find.rs
@@ -29,8 +29,8 @@ fn main() -> io::Result<()> {
             Ok((_, src_addr)) => {
                 if let Ok((_, response)) = el::ElPacket::from_bytes(&buffer) {
                     if response.is_response_for(&packet) {
-                        println!("got response from {}", src_addr);
-                        println!("{}", response);
+                        println!("got response from {src_addr}");
+                        println!("{response}");
                     }
                 }
             }

--- a/echonet-lite-core/src/el_packet.rs
+++ b/echonet-lite-core/src/el_packet.rs
@@ -143,7 +143,7 @@ impl fmt::Display for ServiceCode {
             ServiceCode::InfCRes => "InfCRes",
             ServiceCode::SetGetRes => "SetGetRes",
         };
-        write!(f, "({})", esv)
+        write!(f, "({esv})")
     }
 }
 
@@ -201,7 +201,7 @@ impl fmt::Debug for Properties {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "OPC: {}", self.0.len())?;
         for prop in self.0.iter() {
-            write!(f, "{:?}", prop)?;
+            write!(f, "{prop:?}")?;
         }
         Ok(())
     }
@@ -210,7 +210,7 @@ impl fmt::Debug for Properties {
 impl fmt::Display for Properties {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for prop in self.0.iter() {
-            writeln!(f, "{}", prop)?;
+            writeln!(f, "{prop}")?;
         }
         Ok(())
     }
@@ -274,7 +274,7 @@ impl Clone for Edt {
 impl fmt::Display for Edt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for byte in self.0.iter() {
-            write!(f, "{:02X} ", byte)?;
+            write!(f, "{byte:02X} ")?;
         }
         Ok(())
     }
@@ -285,7 +285,7 @@ impl fmt::Debug for Edt {
         writeln!(f, "PDC: {}", self.0.len())?;
         write!(f, "EDT: ")?;
         for byte in self.0.iter() {
-            write!(f, "{:02X} ", byte)?;
+            write!(f, "{byte:02X} ")?;
         }
         Ok(())
     }

--- a/echonet-lite-core/src/error.rs
+++ b/echonet-lite-core/src/error.rs
@@ -46,14 +46,14 @@ impl From<io::Error> for Error {
 impl fmt::Display for ErrorKind {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ErrorKind::Io(ref ioerr) => write!(fmt, "io error: {}", ioerr),
-            ErrorKind::InvalidUtf8Encoding(ref e) => write!(fmt, "InvalidUtf8Encoding: {}", e),
+            ErrorKind::Io(ref ioerr) => write!(fmt, "io error: {ioerr}"),
+            ErrorKind::InvalidUtf8Encoding(ref e) => write!(fmt, "InvalidUtf8Encoding: {e}"),
             ErrorKind::InvalidBoolEncoding(b) => {
-                write!(fmt, "InvalidBoolEncoding, expected 0 or 1, found {}", b)
+                write!(fmt, "InvalidBoolEncoding, expected 0 or 1, found {b}")
             }
             ErrorKind::InvalidCharEncoding => write!(fmt, "InvalidCharEncoding"),
             ErrorKind::InvalidTagEncoding(tag) => {
-                write!(fmt, "InvalidTagEncoding, found {}", tag)
+                write!(fmt, "InvalidTagEncoding, found {tag}")
             }
             ErrorKind::SequenceMustHaveLength => {
                 write!(fmt, "SequenceMustHaveLength")

--- a/echonet-lite-core/src/object/mod.rs
+++ b/echonet-lite-core/src/object/mod.rs
@@ -104,20 +104,20 @@ impl From<ElPacket> for ClassPacket {
 impl fmt::Display for ClassPacket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ClassPacket::SolarPower(v) => write!(f, "{}", v)?,
-            ClassPacket::StorageBattery(v) => write!(f, "{}", v)?,
-            ClassPacket::Evps(v) => write!(f, "{}", v)?,
-            ClassPacket::Hp(v) => write!(f, "{}", v)?,
-            ClassPacket::SmartMeter(v) => write!(f, "{}", v)?,
-            ClassPacket::AirConditioner(v) => write!(f, "{}", v)?,
-            ClassPacket::Metering(v) => write!(f, "{}", v)?,
-            ClassPacket::FuelCell(v) => write!(f, "{}", v)?,
-            ClassPacket::InstantaneousWaterHeater(v) => write!(f, "{}", v)?,
-            ClassPacket::GeneralLighting(v) => write!(f, "{}", v)?,
-            ClassPacket::MonoFunctionLighting(v) => write!(f, "{}", v)?,
-            ClassPacket::LightingSystem(v) => write!(f, "{}", v)?,
-            ClassPacket::Profile(v) => write!(f, "{}", v)?,
-            ClassPacket::Unimplemented(v) => write!(f, "{}", v)?,
+            ClassPacket::SolarPower(v) => write!(f, "{v}")?,
+            ClassPacket::StorageBattery(v) => write!(f, "{v}")?,
+            ClassPacket::Evps(v) => write!(f, "{v}")?,
+            ClassPacket::Hp(v) => write!(f, "{v}")?,
+            ClassPacket::SmartMeter(v) => write!(f, "{v}")?,
+            ClassPacket::AirConditioner(v) => write!(f, "{v}")?,
+            ClassPacket::Metering(v) => write!(f, "{v}")?,
+            ClassPacket::FuelCell(v) => write!(f, "{v}")?,
+            ClassPacket::InstantaneousWaterHeater(v) => write!(f, "{v}")?,
+            ClassPacket::GeneralLighting(v) => write!(f, "{v}")?,
+            ClassPacket::MonoFunctionLighting(v) => write!(f, "{v}")?,
+            ClassPacket::LightingSystem(v) => write!(f, "{v}")?,
+            ClassPacket::Profile(v) => write!(f, "{v}")?,
+            ClassPacket::Unimplemented(v) => write!(f, "{v}")?,
         }
         Ok(())
     }
@@ -155,10 +155,10 @@ impl fmt::Display for UnimplementedPacket {
         writeln!(f, "Unimplemented Class: {}", self.0)?;
         for prop in self.1.iter() {
             if let Some(name) = SUPER_CLASS.get(&prop.epc) {
-                writeln!(f, "[{}]\t {}", name, prop)?;
+                writeln!(f, "[{name}]\t {prop}")?;
                 continue;
             }
-            writeln!(f, "[unknown]\t {}", prop)?;
+            writeln!(f, "[unknown]\t {prop}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
Recently I realized that there were a handful of clippy warnings; so just ran `cargo clippy --fix` and they all went away.